### PR TITLE
Add `gevent`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="chbmb"
 
 RUN \
+ echo "**** install packages ****" && \
+ apk add --no-cache \
+	py-gevent && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET https://api.github.com/repos/morpheus65535/bazarr/commits/development \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,6 +11,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="chbmb"
 
 RUN \
+echo "**** install packages ****" && \
+ apk add --no-cache \
+	py-gevent && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET https://api.github.com/repos/morpheus65535/bazarr/commits/development \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,6 +11,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="chbmb"
 
 RUN \
+echo "**** install packages ****" && \
+ apk add --no-cache \
+	py-gevent && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET https://api.github.com/repos/morpheus65535/bazarr/commits/development \


### PR DESCRIPTION
New dependency of `gevent` following conversation with Morpheus (Bazarr dev)

```
this one cannot be directly included in bazarr libs and is a prerequisite to start using websocket.
```

Going to add it to the `development` branch for him to test before submitting a PR to master to add the package.

