### PR TITLE
Install requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,13 @@ LABEL maintainer="chbmb"
 ENV TZ="Etc/UTC"
 
 RUN \
-echo "**** install packages ****" && \
- apk add --no-cache \
-	py-gevent && \
+ echo "**** install build packages ****" && \
+ apk add --no-cache --virtual=build-dependencies \
+    g++ \
+    gcc \
+	libxml2-dev \
+	libxslt-dev \
+	python-dev && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET "https://api.github.com/repos/morpheus65535/bazarr/releases/latest" \
@@ -26,12 +30,19 @@ echo "**** install packages ****" && \
  tar xf \
  /tmp/bazarr.tar.gz -C \
 	/app/bazarr --strip-components=1 && \
+ echo "**** Install requirements ****" && \
+ pip install --no-cache-dir -U  -r \
+     /app/bazarr/requirements.txt && \ 
  echo "**** fix backports warning in log ****" && \
  if [ ! -e /usr/lib/python2.7/site-packages/backports/__init__.py ]; \
 	then \
  	touch /usr/lib/python2.7/site-packages/backports/__init__.py ; \
  fi && \
+ echo "**** clean up ****" && \
+ apk del --purge \
+    build-dependencies && \
  rm -rf \
+    /root/.cache \
 	/tmp/*
 
 # add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/python:3.9
+FROM lsiobase/alpine:3.9
 
 # set version label
 ARG BUILD_DATE
@@ -12,11 +12,21 @@ ENV TZ="Etc/UTC"
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-    g++ \
-    gcc \
+	g++ \
+	gcc \
 	libxml2-dev \
 	libxslt-dev \
-	python-dev && \
+	py2-pip \
+	python2-dev && \
+ echo "**** install packages ****" && \
+ apk add --no-cache \
+	curl \
+	ffmpeg \
+	libxml2 \
+	libxslt \ 
+	python2 \
+	unrar \
+	unzip && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET "https://api.github.com/repos/morpheus65535/bazarr/releases/latest" \
@@ -30,19 +40,15 @@ RUN \
  tar xf \
  /tmp/bazarr.tar.gz -C \
 	/app/bazarr --strip-components=1 && \
+ rm -Rf /app/bazarr/bin && \
  echo "**** Install requirements ****" && \
  pip install --no-cache-dir -U  -r \
-     /app/bazarr/requirements.txt && \ 
- echo "**** fix backports warning in log ****" && \
- if [ ! -e /usr/lib/python2.7/site-packages/backports/__init__.py ]; \
-	then \
- 	touch /usr/lib/python2.7/site-packages/backports/__init__.py ; \
- fi && \
+	/app/bazarr/requirements.txt && \ 
  echo "**** clean up ****" && \
  apk del --purge \
-    build-dependencies && \
+	build-dependencies && \
  rm -rf \
-    /root/.cache \
+	/root/.cache \
 	/tmp/*
 
 # add local files

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -10,9 +10,12 @@ LABEL maintainer="chbmb"
 ENV TZ="Etc/UTC"
 
 RUN \
-echo "**** install packages ****" && \
- apk add --no-cache \
-	py-gevent && \
+ echo "**** install build packages ****" && \
+ apk add --no-cache --virtual=build-dependencies \
+    g++ \
+    gcc \
+	libxml2-dev \
+	python-dev && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET "https://api.github.com/repos/morpheus65535/bazarr/releases/latest" \
@@ -26,12 +29,19 @@ echo "**** install packages ****" && \
  tar xf \
  /tmp/bazarr.tar.gz -C \
 	/app/bazarr --strip-components=1 && \
+ echo "**** Install requirements ****" && \
+ pip install --no-cache-dir -U  -r \
+     /app/bazarr/requirements.txt && \ 
  echo "**** fix backports warning in log ****" && \
  if [ ! -e /usr/lib/python2.7/site-packages/backports/__init__.py ]; \
 	then \
  	touch /usr/lib/python2.7/site-packages/backports/__init__.py ; \
  fi && \
+ echo "**** clean up ****" && \
+ apk del --purge \
+    build-dependencies && \
  rm -rf \
+    /root/.cache \
 	/tmp/*
 
 # add local files

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,6 +15,7 @@ RUN \
     g++ \
     gcc \
 	libxml2-dev \
+	libxslt-dev \
 	python-dev && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/python:arm64v8-3.9
+FROM lsiobase/alpine:arm64v8-3.9
 
 # set version label
 ARG BUILD_DATE
@@ -12,11 +12,21 @@ ENV TZ="Etc/UTC"
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-    g++ \
-    gcc \
+	g++ \
+	gcc \
 	libxml2-dev \
 	libxslt-dev \
-	python-dev && \
+	py2-pip \
+	python2-dev && \
+ echo "**** install packages ****" && \
+ apk add --no-cache \
+	curl \
+	ffmpeg \
+	libxml2 \
+	libxslt \ 
+	python2 \
+	unrar \
+	unzip && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET "https://api.github.com/repos/morpheus65535/bazarr/releases/latest" \
@@ -30,19 +40,15 @@ RUN \
  tar xf \
  /tmp/bazarr.tar.gz -C \
 	/app/bazarr --strip-components=1 && \
+ rm -Rf /app/bazarr/bin && \
  echo "**** Install requirements ****" && \
  pip install --no-cache-dir -U  -r \
-     /app/bazarr/requirements.txt && \ 
- echo "**** fix backports warning in log ****" && \
- if [ ! -e /usr/lib/python2.7/site-packages/backports/__init__.py ]; \
-	then \
- 	touch /usr/lib/python2.7/site-packages/backports/__init__.py ; \
- fi && \
+	/app/bazarr/requirements.txt && \ 
  echo "**** clean up ****" && \
  apk del --purge \
-    build-dependencies && \
+	build-dependencies && \
  rm -rf \
-    /root/.cache \
+	/root/.cache \
 	/tmp/*
 
 # add local files

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/python:arm32v7-3.9
+FROM lsiobase/alpine:arm32v7-3.9
 
 # set version label
 ARG BUILD_DATE
@@ -12,11 +12,21 @@ ENV TZ="Etc/UTC"
 RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
-    g++ \
-    gcc \
+	g++ \
+	gcc \
 	libxml2-dev \
 	libxslt-dev \
-	python-dev && \
+	py2-pip \
+	python2-dev && \
+ echo "**** install packages ****" && \
+ apk add --no-cache \
+	curl \
+	ffmpeg \
+	libxml2 \
+	libxslt \ 
+	python2 \
+	unrar \
+	unzip && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET "https://api.github.com/repos/morpheus65535/bazarr/releases/latest" \
@@ -30,19 +40,15 @@ RUN \
  tar xf \
  /tmp/bazarr.tar.gz -C \
 	/app/bazarr --strip-components=1 && \
+ rm -Rf /app/bazarr/bin && \
  echo "**** Install requirements ****" && \
  pip install --no-cache-dir -U  -r \
-     /app/bazarr/requirements.txt && \ 
- echo "**** fix backports warning in log ****" && \
- if [ ! -e /usr/lib/python2.7/site-packages/backports/__init__.py ]; \
-	then \
- 	touch /usr/lib/python2.7/site-packages/backports/__init__.py ; \
- fi && \
+	/app/bazarr/requirements.txt && \ 
  echo "**** clean up ****" && \
  apk del --purge \
-    build-dependencies && \
+	build-dependencies && \
  rm -rf \
-    /root/.cache \
+	/root/.cache \
 	/tmp/*
 
 # add local files

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -10,9 +10,12 @@ LABEL maintainer="chbmb"
 ENV TZ="Etc/UTC"
 
 RUN \
-echo "**** install packages ****" && \
- apk add --no-cache \
-	py-gevent && \
+ echo "**** install build packages ****" && \
+ apk add --no-cache --virtual=build-dependencies \
+    g++ \
+    gcc \
+	libxml2-dev \
+	python-dev && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \
 	BAZARR_VERSION=$(curl -sX GET "https://api.github.com/repos/morpheus65535/bazarr/releases/latest" \
@@ -26,12 +29,19 @@ echo "**** install packages ****" && \
  tar xf \
  /tmp/bazarr.tar.gz -C \
 	/app/bazarr --strip-components=1 && \
+ echo "**** Install requirements ****" && \
+ pip install --no-cache-dir -U  -r \
+     /app/bazarr/requirements.txt && \ 
  echo "**** fix backports warning in log ****" && \
  if [ ! -e /usr/lib/python2.7/site-packages/backports/__init__.py ]; \
 	then \
  	touch /usr/lib/python2.7/site-packages/backports/__init__.py ; \
  fi && \
+ echo "**** clean up ****" && \
+ apk del --purge \
+    build-dependencies && \
  rm -rf \
+    /root/.cache \
 	/tmp/*
 
 # add local files

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,6 +15,7 @@ RUN \
     g++ \
     gcc \
 	libxml2-dev \
+	libxslt-dev \
 	python-dev && \
  echo "**** install bazarr ****" && \
  if [ -z ${BAZARR_VERSION+x} ]; then \

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.06.19:** - Swap to install deps using maintainers requirements.txt, add ffmpeg for ffprobe.
 * **17.04.19:** - Add default UTC timezone if user does not set it.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **22.02.19:** - Rebasing to alpine 3.9.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,6 +44,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "12.06.19:", desc: "Swap to install deps using maintainers requirements.txt, add ffmpeg for ffprobe." }
   - { date: "17.04.19:", desc: "Add default UTC timezone if user does not set it." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "22.02.19:", desc: "Rebasing to alpine 3.9." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,5 +2,4 @@
 
 # permissions
 chown -R abc:abc \
-	/app \
 	/config


### PR DESCRIPTION
RE: https://github.com/morpheus65535/bazarr/issues/461

Only thing that stood out was we were missing `lxml` and we install `py-gevents` from the Alpine repository rather than via pip which means it's a little older.  (`1.3.4r0` vs `1.4.0`)

Switch to pip install means it will be easier to track upstream requirements.

No idea if it will fix the issue above or not.