### PR TITLE
Fix Bazarr crashing on startup due to missing libopenblas.so.3 (numpy dependency)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN \
     ffmpeg \
     libxml2 \
     libxslt \
+    openblas \
     py3-pip \
     python3 \
     unrar \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -27,6 +27,7 @@ RUN \
     ffmpeg \
     libxml2 \
     libxslt \
+    openblas \
     py3-pip \
     python3 \
     unrar \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -27,6 +27,7 @@ RUN \
     ffmpeg \
     libxml2 \
     libxslt \
+    openblas \
     py3-pip \
     python3 \
     unrar \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,6 +46,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.10.21:", desc: "Added openblas package to prevent numpy error." }
   - { date: "16.05.21:", desc: "Use wheel index." }
   - { date: "19.04.21:", desc: "Install from release zip." }
   - { date: "07.04.21:", desc: "Move app to /app/bazarr/bin." }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bazarr/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Added openblas to installed packages, to fix numpy dependency issue (see #77)

## Benefits of this PR and context:
Fixes Bazarr crashing on startup due to missing numpy dependency `libopenblas.so.3`

## How Has This Been Tested?
Tested on my Ubuntu 21.10 machine:
1. `docker build  --no-cache  --pull  -t linuxserver/bazarr:development .`
2. `docker run -p 6767:6767 linuxserver/bazarr:development`
3. Ensured the error does not show up in the output of the container (and no other errors do).
4. Tried to access Bazarr on http://localhost:6767. Bazarr is reachable again (in contrast to the 1.0.1 tagged release).

## Source / References:
See #77 for logs and issue details.
