### PR TITLE
install Openssl1.1-compat to support sites with older ciphers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN \
     ffmpeg \
     libxml2 \
     libxslt \
+    openssl1.1-compat \
     python3 && \
   echo "**** install unrar from source ****" && \
   mkdir /tmp/unrar && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -26,6 +26,7 @@ RUN \
     ffmpeg \
     libxml2 \
     libxslt \
+    openssl1.1-compat \
     python3 && \
   echo "**** install unrar from source ****" && \
   mkdir /tmp/unrar && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -26,6 +26,7 @@ RUN \
     ffmpeg \
     libxml2 \
     libxslt \
+    openssl1.1-compat \
     python3 && \
   echo "**** install unrar from source ****" && \
   mkdir /tmp/unrar && \

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.02.23:** - Install openssl1.1-compat.
 * **23.01.23:** - Rebase master branch to Alpine 3.17.
 * **11.10.22:** - Rebase master branch to Alpine 3.16, migrate to s6v3.
 * **15.15.21:** - Temp fix for lxml, compile from scratch to avoid broken official wheel.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.02.23:", desc: "Install openssl1.1-compat." }
   - { date: "23.01.23:", desc: "Rebase master branch to Alpine 3.17." }
   - { date: "11.10.22:", desc: "Rebase master branch to Alpine 3.16, migrate to s6v3." }
   - { date: "15.15.21:", desc: "Temp fix for lxml, compile from scratch to avoid broken official wheel." }


### PR DESCRIPTION
closes https://github.com/linuxserver/docker-bazarr/issues/106
adds in openssl1.1-compat, which is still supported (LTS) until Sep2023. It supposed secmode=1 for older ciphers which the above issue's site needs.