### PR TITLE
fix: add healtchecks and probes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN \
     libxml2 \
     libxslt \
     mediainfo \
-    python3 && \
+    python3 \
+    yq && \
   echo "**** install bazarr ****" && \
   mkdir -p \
     /app/bazarr/bin && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -29,7 +29,8 @@ RUN \
     libxml2 \
     libxslt \
     mediainfo \
-    python3 && \
+    python3 \
+    yq && \
   echo "**** install bazarr ****" && \
   mkdir -p \
     /app/bazarr/bin && \

--- a/root/usr/local/bin/healthcheck.sh
+++ b/root/usr/local/bin/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+# The location of the config file can be overcontrolled via the environment
+# variable CONFIG_FILE.
+CONFIG_FILE=${CONFIG_FILE:-"/config/config/config.yaml"}
+
+# Extract config parameters to query status via API.
+API_KEY=$(yq -r '.auth.apikey' "${CONFIG_FILE}")
+PORT=$(yq -r '.general.port' "${CONFIG_FILE}")
+
+curl --silent --insecure --fail --output /dev/null "http://localhost:${PORT}/api/system/status?apikey=${API_KEY}"

--- a/root/usr/local/bin/liveness.sh
+++ b/root/usr/local/bin/liveness.sh
@@ -1,0 +1,1 @@
+healthcheck.sh

--- a/root/usr/local/bin/readyness.sh
+++ b/root/usr/local/bin/readyness.sh
@@ -1,0 +1,1 @@
+healthcheck.sh


### PR DESCRIPTION
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-bazarr/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Starting with version 1.4.0 of bazarr, the configuration file format has been changed from [ini to yaml](https://github.com/morpheus65535/bazarr/commit/c89da3e6192a519ccefa6bb7d9f9c9eaa280d373). This make it easier to parse the config file for properties via `yq`. For example to implement a healthcheck for docker or probes for kubernetes. Neither a healthcheck nor probes is contained in the container image. This leads users to develop their own healthcheck like I developed in the past an awk script. This pull request adds default shell scripts for booth platforms to provide a healthchecks and probes. 

## Benefits of this PR and context:

This PR adds additional shell scripts which can be executed on different platforms. For example for docker and kubernetes. On docker there can be executed the `healthcheck.sh` and on kubernetes `liveness.sh` and `readyness.sh`. Currently are the scripts for kubernetes symbolic links to the `healthcheck.sh` file, but the symlink can be removed in the future, when the implementation between booth platforms are different. 

I skipped the `HEALTHCHECK` definition in the `Dockerfile`, because it is docker specific staff and not supported by the official container spec. We can add a `HEALTHCHECK` definition as default, but I like to skip it, because maybe it can break user environments. For example, when the healthcheck requires to much CPU time and returns a failure, which leads to be an unhealthy container. Other applications can consume this state, like reverse proxy servers. This reverse proxy servers can skip the application and leads to an unreachable bazarr instance. 


## How Has This Been Tested?

Executed the healthcheck locally: 

```bash
$ docker build -t localhost/bazarr:latest --no-cache .
$ docker run --rm --detach --health-cmd /usr/local/bin/healthcheck.sh --health-retries 3 --health-timeout 5s localhost/bazarr:latest`
$ docker ps
CONTAINER ID   IMAGE                               COMMAND   CREATED          STATUS                    PORTS      NAMES
ab2f74a6092a   localhost/bazarr:latest   "/init"   23 minutes ago   Up 23 minutes (healthy)   6767/tcp   frosty_neumann
```